### PR TITLE
Exposes Multipart properties for broader use

### DIFF
--- a/Sources/Multipart/Boundary.swift
+++ b/Sources/Multipart/Boundary.swift
@@ -1,15 +1,14 @@
 import Foundation
 
 /// Defines a random string that can be used as boundary in MIME-encoded messages.
-struct Boundary {
+public struct Boundary {
+    public let stringValue: String
     
-    let stringValue: String
+    public var delimiter: String { return "--" + self.stringValue }
+    public var distinguishedDelimiter: String { return self.delimiter + "--" }
     
-    var delimiter: String { return "--" + self.stringValue }
-    var distinguishedDelimiter: String { return self.delimiter + "--" }
-    
-    var delimiterData: Data { return self.delimiter.data(using: .utf8)! }
-    var distinguishedDelimiterData: Data { return self.distinguishedDelimiter.data(using: .utf8)! }
+    public var delimiterData: Data { return self.delimiter.data(using: .utf8)! }
+    public var distinguishedDelimiterData: Data { return self.distinguishedDelimiter.data(using: .utf8)! }
     
     init() {
         self.stringValue = (UUID().uuidString + UUID().uuidString).replacingOccurrences(of: "-", with: "")

--- a/Sources/Multipart/Multipart.swift
+++ b/Sources/Multipart/Multipart.swift
@@ -3,8 +3,8 @@ import Foundation
 /// Defines a message in which one or more different sets of data are combined according to the MIME standard.
 /// - SeeAlso: Defined in [RFC 2046, Section 5.1](https://tools.ietf.org/html/rfc2046#section-5.1)
 public struct Multipart {
-    static let CRLF = "\r\n"
-    static let CRLFData = Multipart.CRLF.data(using: .utf8)!
+    public static let CRLF = "\r\n"
+    public static let CRLFData = Multipart.CRLF.data(using: .utf8)!
     
     /// A string that is optionally inserted before the first boundary delimiter. Can be used as an explanatory note for
     /// recipients who read the message with pre-MIME software, since such notes will be ignored by MIME-compliant software.
@@ -13,9 +13,9 @@ public struct Multipart {
     /// Message headers that apply to this body part.
     public var headers: [MessageHeader] = []
     
-    let type: Subtype
-    let boundary = Boundary()
-    var entities: [MultipartEntity]
+    public let type: Subtype
+    public let boundary = Boundary()
+    public private(set) var entities: [MultipartEntity]
     
     /// Creates and initializes a Multipart body with the given subtype.
     /// - Parameter type: The multipart subtype


### PR DESCRIPTION
Makes the `CRLF` constant, `type`, `boundary`, and `entities` properties of the `Multipart` struct public.
This allows for easier access and manipulation of these properties from outside the struct, increasing flexibility and reusability.
